### PR TITLE
调整一些宏包和命令

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,28 +1,13 @@
-\documentclass[12pt, openany]{book}
+\documentclass[12pt, openany]{ctexbook}
 
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{graphicx}
 \usepackage{geometry}
-\usepackage[UTF8, heading=true]{ctex}
-\usepackage{fontspec}
 \usepackage{subfiles}
-\usepackage{hyperref}
 \usepackage{authblk}
 \usepackage{fontawesome}
-
 \usepackage{xcolor}
-
-% 魔法改造开始喵！
-\makeatletter
-\let\oldhref\href
-\renewcommand{\href}[2]{%
-  \oldhref{#1}{%
-    \color{blue}\underline{#2}%
-    \raisebox{0.2ex}{\tiny$\nearrow$}% 右上箭头
-  }%
-}
-\makeatother
 
 \usepackage{tikz}
 \usetikzlibrary{arrows.meta, positioning, shapes, calc}
@@ -32,10 +17,23 @@
 \SetWatermarkText{LCPU-2025}           % 设置水印内容
 %\SetWatermarkText{\includegraphics{fig/texlion.png}}         % 设置水印logo
 \SetWatermarkLightness{0.975}             % 设置水印透明度 0-1
-\SetWatermarkScale{1}                   % 设置水印大小 0-1  
+\SetWatermarkScale{1}                   % 设置水印大小 0-1
 
 \geometry{a4paper, margin=1in}
-
+\usepackage{hyperref}
+% 魔法改造开始喵！
+\ExplSyntaxOn
+\cs_set_eq:NN \__old_href:nn \href
+\RenewDocumentCommand { \href } { m m }
+  {
+    \__old_href:nn {#1}
+      {
+        \color { blue }
+        \underline{#2}
+        \raisebox { 0.2 ex } { \tiny $\nearrow$ }
+      }
+  }
+\ExplSyntaxOff
 \title{\Huge\textbf{计算概论衔接课讲义}}
 \author[a]{臧炫懿}
 \affil[a]{北京大学信息科学技术学院}
@@ -91,7 +89,7 @@
 
 \subfile{chapters/08-play-with-linux.tex}
 
-\backmatter 
+\backmatter
 
 \chapter{致谢}
 
@@ -101,7 +99,7 @@
 
 \begin{itemize}
   \item LCPU Getting Started 全体成员
-  \item \faGithub\href{https://github.com/Elkeid-mer}{Elkeid-mer}
+  \item \faGithub\href{https://github.com/Elkeid-me}{Elkeid-me}
 \end{itemize}
 
 最后，感谢每一位愿意花时间阅读、使用并反馈这份讲义的同学。愿你们在代码与终端的世界里，既能脚踏实地，又能仰望星空；既能把系统玩得风生水起，也能把生活过得热气腾腾。

--- a/main.tex
+++ b/main.tex
@@ -1,5 +1,6 @@
-\documentclass[12pt, openany]{ctexbook}
+\documentclass[12pt, openany]{book}
 
+\usepackage[UTF8, heading=true]{ctex}
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{graphicx}
@@ -22,18 +23,15 @@
 \geometry{a4paper, margin=1in}
 \usepackage{hyperref}
 % 魔法改造开始喵！
-\ExplSyntaxOn
-\cs_set_eq:NN \__old_href:nn \href
-\RenewDocumentCommand { \href } { m m }
-  {
-    \__old_href:nn {#1}
-      {
-        \color { blue }
-        \underline{#2}
-        \raisebox { 0.2 ex } { \tiny $\nearrow$ }
-      }
-  }
-\ExplSyntaxOff
+\makeatletter
+\let\oldhref\href
+\renewcommand{\href}[2]{%
+  \oldhref{#1}{%
+    \color{blue}\underline{#2}%
+    \raisebox{0.2ex}{\tiny$\nearrow$}% 右上箭头
+  }%
+}
+\makeatother
 \title{\Huge\textbf{计算概论衔接课讲义}}
 \author[a]{臧炫懿}
 \affil[a]{北京大学信息科学技术学院}


### PR DESCRIPTION
这个 PR 没有添加实质性内容，只是改了 `main.tex`。

1. 将文档类换为 `ctexbook`。`ctexbook` 等同于 `book` 文档类与使用 `heading=true` 选项的 `ctex` 包。
2. UTF-8 是 `ctex` 的默认行为，删去 `ctex` 包的 `UTF8` 选项。
3. 在 XeLaTeX 和 LuaLaTeX 上，`ctex` 会自动调用 `fontspec`，删去对 `fontspec` 的显式调用。
4. 根据 [`hyperref` 的手册](https://mirrors.pku.edu.cn/ctan/macros/latex/contrib/hyperref/doc/hyperref-doc.html#:~:text=Make%20sure%20it%20comes%20last%20of%20your%20loaded%20packages)，`hyperref` 应当作为最后一个调用的宏包。
5. 使用更现代化的方式重定义 `\href`。