### PR TITLE
修正有关MSYS2的若干错误

### DIFF
--- a/chapters/05-coding.tex
+++ b/chapters/05-coding.tex
@@ -56,7 +56,7 @@ Linux和Mac用户可以通过包管理器安装特定的编译器，在暑假课
 
 你需要在\href{https://www.msys2.org/}{MSYS2官网}下载最新的安装包，并按照官网的说明进行安装。安装完成后，你可以通过MSYS2的包管理器pacman来安装GCC。
 
-你可以在MSYS2终端中运行以下命令来安装GCC和GDB（建议使用UCRT64终端，不建议用其他的几个，它们即将停止支持）：
+你可以在MSYS2终端中运行以下命令来安装GCC和GDB（建议使用UCRT64终端，不建议使用逐渐失去支持的32位以及MINGW64环境，也不建议新手使用CLANG64环境，该环境完全使用Clang代替GCC）：
 
 \begin{lstlisting}[language=bash]
 pacman -S mingw-w64-ucrt-x86_64-gcc
@@ -69,9 +69,9 @@ pacman -S mingw-w64-ucrt-x86_64-gdb
 
 \begin{itemize}
   \item 找到MSYS2的安装目录，通常是\texttt{C:\textbackslash msys64}。
-  \item 将\texttt{C:\textbackslash msys64\textbackslash ucrt64\textbackslash bin}添加到系统的PATH环境变量中。
+  \item 将\texttt{C:\textbackslash msys64\textbackslash ucrt64\textbackslash bin}添加到系统的PATH环境变量中。（请按照你的实际安装路径进行调整，下同）
   \item 在PowerShell或者CMD中运行以下命令来验证是否配置成功：\texttt{gcc --version}。如果输出了GCC的版本信息，则说明配置成功。
-  \item 如以上办法不起作用，可以尝试将\texttt{C:\textbackslash msys64\textbackslash usr\textbackslash bin}也添加到用户的PATH环境变量中。
+  \item 需要在Windows的PowerShell或者CMD中运行POSIX风格工具时，也可以将\texttt{C:\textbackslash msys64\textbackslash usr\textbackslash bin}也添加到用户的PATH环境变量中。但这样具有环境冲突风险，需要注意保证该变量的查找顺序在比ucrt64的bin目录更靠后，以避免冲突。
 \end{itemize}
 
 \emph{特别注意：有的同学可能不是按照上述推荐的方式安装GCC的，而是通过其他方式（例如直接下载预编译版本）安装的GCC。如果是这种情况，务必记住GCC和非ASCII字符是死敌，因此请不要将GCC安装在包含非ASCII字符（如汉字、空格）的路径下！（最大的坑可能是你的用户名中包含非ASCII字符，例如汉字！）}


### PR DESCRIPTION
* UCRT64外的其他环境并非都停止支持，CLANG64支持良好，但出于兼容考虑不建议新手使用
* MSYS2的安装路径并非固定，对MSYS2安装在其他路径的情况作说明
* 添加msys64/usr/bin对无法正常使用GCC没有帮助，甚至可能导致冲突，只能起到给Windows用POSIX工具的作用，并不能建议在GCC不起作用时添加